### PR TITLE
feat: Allow access from Render.com and local development

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -5,7 +5,7 @@ import dj_database_url
 DEBUG = True
 
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["it-company-task-manage-1.onrender.com", "127.0.0.1"]
 
 
 # Database

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -10,7 +10,7 @@ from .base import *
 DEBUG = False
 
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["it-company-task-manage-1.onrender.com", "127.0.0.1"]
 
 
 


### PR DESCRIPTION
Set the ALLOWED_HOSTS in dev and prod settings to include the Render.com deployment and the local development server. This allows the application to be accessed from both environments.