### PR TITLE
feat(ui): remove signup link from login page

### DIFF
--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -24,9 +24,5 @@
       <input type="hidden" name="next" value="{{ next }}" />
     </div>
   </form>
-
-  <div class="mt-3">
-    <p>Don't have an account? <a href="{% url 'register' %}">Sign up here</a>.</p>
-  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
The signup link on the login page is no longer necessary as the user can access the registration page from the homepage. This removes unnecessary clutter on the login page.